### PR TITLE
Upgrade Kafka to 1.0.0 and add listener env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,54 @@ in the same container. This means:
 * No dependency on an external Zookeeper host, or linking to another container.
 * Zookeeper and Kafka are configured to work together out of the box.
 
-Run
+Simple Run
 ---
 
 Start the container:
 
 ```bash
-docker run -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=localhost --env ADVERTISED_PORT=9092 spotx/kafka:0.10.2.0
+docker run -p 2181:2181 -p 9092:9092 spotx/kafka:1.0.0
+```
+
+Write a test message to kafka:
+
+```bash
+docker exec -it <container_id> ./opt/kafka_2.11-1.0.0/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test
+```
+
+Read the test message:
+
+```bash
+docker exec -it <container_id> ./opt/kafka_2.11-1.0.0/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
+```
+
+Complex Run
+---
+
+In a more complex setup, internal and external listeners can be defined
+to allow access from outside the container
+
+1. Configure with Docker Compose file:
+
+```
+version: '3'
+services:
+  kafka:
+    image: spotx/kafka:1.0.0
+    ports:
+    - "2181:2181"
+    - "9092:9094"
+    environment:
+      KAFKA_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://kafka:9094
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+```
+
+2. Start service
+
+```bash
+docker-compose -f <compose_file>.yml up
 ```
 
 Write a test message to kafka:
@@ -32,7 +73,7 @@ kafka-console-producer.sh --broker-list localhost:9092 --topic test
 Read the test message:
 
 ```bash
-kafka-console-consumer.sh --bootstrap-server localhost:9092 --from-beginning --topic test
+kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
 ```
 
 In the box

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,10 +1,10 @@
 # Kafka and Zookeeper
 
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 0.10.2.0
+ENV KAFKA_VERSION 1.0.0
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
 
 # Install Kafka, Zookeeper and other needed things

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -1,12 +1,24 @@
 #!/bin/sh
 
 # Optional ENV variables:
-# * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
-# * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
+#
+# * ADVERTISED_HOST (DEPRECATED): the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
+# * ADVERTISED_PORT (DEPRECATED): the external port for Kafka, e.g. 9092
+#
+# * KAFKA_LISTENERS: The host/ip(s) Kafka binds to listen on, e.g. "INTERNAL://kafka:9092,EXTERNAL://kafka:9094"
+# * KAFKA_ADVERTISED_LISTENERS: Listener metadata which can be passed back to clients, e.g. "INTERNAL://kafka:9092,EXTERNAL://localhost:9094"
+# * KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: Defines key/value pairs for the security protocol to use, e.g. "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+# * KAFKA_INTER_BROKER_LISTENER_NAME: Name of listener used for communication between brokers, e.g. "INTERNAL"
+#
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
 # * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
 # * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
 # * NUM_PARTITIONS: configure the default number of log partitions per topic
+
+# Add new line before adding any config into server.properties.
+# This prevents a property being added onto the same line as 
+# another property
+echo "" >> $KAFKA_HOME/config/server.properties
 
 # Configure advertised host/port if we run in helios
 if [ ! -z "$HELIOS_PORT_kafka" ]; then
@@ -15,6 +27,10 @@ if [ ! -z "$HELIOS_PORT_kafka" ]; then
 fi
 
 # Set the external host and port
+#
+# NOTE: advertiser.host.name and advertised.port are deprecated in Kafka - they remain
+# here for backwards compatibility. Listeners should be used instead.
+# More info: https://kafka.apache.org/10/documentation.html#brokerconfigs
 if [ ! -z "$ADVERTISED_HOST" ]; then
     echo "advertised host: $ADVERTISED_HOST"
     echo "advertised.host.name=$ADVERTISED_HOST" >> $KAFKA_HOME/config/server.properties
@@ -22,6 +38,24 @@ fi
 if [ ! -z "$ADVERTISED_PORT" ]; then
     echo "advertised port: $ADVERTISED_PORT"
     echo "advertised.port=$ADVERTISED_PORT" >> $KAFKA_HOME/config/server.properties
+fi
+
+# Configure listeners and security protocol
+if [ ! -z "$KAFKA_LISTENERS" ]; then
+    echo "kafka listeners: $KAFKA_LISTENERS"
+    echo "listeners=$KAFKA_LISTENERS" >> $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$KAFKA_ADVERTISED_LISTENERS" ]; then
+    echo "kafka advertised listeners: $KAFKA_ADVERTISED_LISTENERS"
+    echo "advertised.listeners=$KAFKA_ADVERTISED_LISTENERS" >> $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$KAFKA_LISTENER_SECURITY_PROTOCOL_MAP" ]; then
+    echo "kafka listener security protocol map: $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"
+    echo "listener.security.protocol.map=$KAFKA_LISTENER_SECURITY_PROTOCOL_MAP" >> $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$KAFKA_INTER_BROKER_LISTENER_NAME" ]; then
+    echo "kafka inter broker listener name: $KAFKA_INTER_BROKER_LISTENER_NAME"
+    echo "inter.broker.listener.name=$KAFKA_INTER_BROKER_LISTENER_NAME" >> $KAFKA_HOME/config/server.properties
 fi
 
 # Set the zookeeper chroot


### PR DESCRIPTION
advertised.host.name and advertised.port have been deprecated in favour of listeners. More info here: https://kafka.apache.org/10/documentation.html#brokerconfigs